### PR TITLE
Use WizardCard for gallery

### DIFF
--- a/components/Lore/WizarMapLeaflet.tsx
+++ b/components/Lore/WizarMapLeaflet.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import { GeoJsonObject } from "geojson";
 import { MapWrapper } from "../Map";
 import { Box } from "rebass";
-import WizardCardNoBorder from "../WizardCardNoBorder";
+import WizardCard from "../WizardCard";
 
 const wizData = productionWizardData as { [wizardId: string]: any };
 
@@ -63,8 +63,8 @@ const WizardPopup = ({
 }) => {
   return (
     <Box width={250} style={{ fontSize: 12 }}>
-      <WizardCardNoBorder
-        id={index}
+      <WizardCard
+        id={index.toString()}
         name={name}
         showOpenSeaLink={true}
         showLoreLink={true}

--- a/components/WizardCard.tsx
+++ b/components/WizardCard.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { useState } from "react";
+import { Box } from "rebass";
 import { WizardConfiguration } from "./AddLore/WizardPicker";
+import { ResponsivePixelImg } from "./ResponsivePixelImg";
 
 const image_base_url =
   "https://nftz.forgottenrunes.com/wizards/alt/400-nobg/wizard-";
@@ -67,14 +69,24 @@ const WizardName = styled.div`
   }
 `;
 
+const Links = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 const WizardCard = ({
   id,
   name,
-  onWizardPicked
+  onWizardPicked,
+  showOpenSeaLink = false,
+  showLoreLink = false,
 }: {
   id: string;
   name: string;
   onWizardPicked?: (wizardConfiguration: WizardConfiguration) => void;
+  showOpenSeaLink?: boolean;
+  showLoreLink?: boolean;
 }) => {
   const [isHovering, setIsHovering] = useState(false);
 
@@ -107,6 +119,33 @@ const WizardCard = ({
           <WizardImage src={image_base_url + id + ".png"} />
         </WizardImageContainer>
       </WizardFrame>
+      <Links>
+        {showOpenSeaLink ? (
+              <>
+                <a
+                  href={`${opensea_base_url}${id}`}
+                  target={"_blank"}
+                  className="icon-link"
+                  title={"OpenSea"}
+                >
+                  <ResponsivePixelImg src="/static/img/icons/social_opensea_default_w.png" />
+                </a>
+              </>
+            ) : null}
+            <Box ml={3} />
+            {showLoreLink ? (
+              <>
+                <a
+                  href={`/lore/${id}/0`}
+                  className="icon-link"
+                  title={"Lore"}
+                  target={"_blank"}
+                >
+                  <ResponsivePixelImg src="/static/img/icons/social_link_default.png" />
+                </a>
+              </>
+            ) : null}
+        </Links>
     </CardStyle>
   );
 };


### PR DESCRIPTION
<img width="384" alt="Screen Shot 2021-08-21 at 1 12 58 PM" src="https://user-images.githubusercontent.com/1606986/130333758-fac05a17-621c-4e77-adc1-b881c771ff42.png">

Not sure exactly the layout we want for the link icons, but here's a change to use `WizardCard` in the gallery. Maybe better to have the link icons inside the frame though? Can try that too if it makes more sense